### PR TITLE
Relax requirements of .NET 9 dependencies >= 8.* < 10

### DIFF
--- a/benchmarks/OpenTracing.Contrib.NetCore.Benchmarks/OpenTracing.Contrib.NetCore.Benchmarks.csproj
+++ b/benchmarks/OpenTracing.Contrib.NetCore.Benchmarks/OpenTracing.Contrib.NetCore.Benchmarks.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[9.0.0,10)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.0,10)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
+++ b/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
@@ -4,7 +4,7 @@
     <PackageId>Ocbj.OpenTracing.Contrib.NetCore</PackageId>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <!-- Not expecting this fork to change much, so manually updating version is fine -->
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Description>
       Adds OpenTracing instrumentation for .NET Core apps that use the `Microsoft.Extensions.*` stack.

--- a/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
+++ b/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
@@ -67,15 +67,15 @@
 
   <ItemGroup Condition="$(TargetFramework)=='net9.0'">
     <!-- Main dependencies -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.0,10)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,10)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[9.0.0,10)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[9.0.0,10)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[9.0.0,10)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.0,10)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.0,10)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0,10)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.0,10)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[8.0.0,10)" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.0,10)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[9.0.0,10)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.0,10)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[8.0.0,10)" PrivateAssets="All" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/OpenTracing.Contrib.NetCore.Tests/OpenTracing.Contrib.NetCore.Tests.csproj
+++ b/test/OpenTracing.Contrib.NetCore.Tests/OpenTracing.Contrib.NetCore.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[9.0.0,10)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.0,10)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We're not specifically using anything added in 9.* versions of those packages.
We already allow 8.* dependencies as per .NET 8 target, so relax the requirement.